### PR TITLE
FRAM1-2698: Rails 8 compatibility for serialize

### DIFF
--- a/lib/i18n/backend/active_record/translation.rb
+++ b/lib/i18n/backend/active_record/translation.rb
@@ -61,7 +61,7 @@ module I18n
           if: -> { self.entity_id.present? || self.entity_type == "" }
 
         serialize :value
-        serialize :interpolations, Array
+        serialize :interpolations, coder: YAML, type: Array
         after_commit :invalidate_translations_cache
 
         class << self


### PR DESCRIPTION
## Summary

- Rails 7.1+ removed the positional `serialize :attr, ClassName` signature. `Translation` used `serialize :interpolations, Array`, which raises `ArgumentError` at gem-load time — so `visit_widget_web` can't boot once it moves to **Rails 8.1.3** (FRAM1-2698).

## Changes

- `lib/i18n/backend/active_record/translation.rb`: `serialize :interpolations, Array` → `serialize :interpolations, coder: YAML, type: Array` (keyword form; the YAML coder + `Array` type preserves the existing on-disk format).

Part of FRAM1-2698 (VW Web/Analytics/Email Rails 8 upgrade). `visit_widget_web`'s Gemfile `ref:` points at this branch's commit so web can bundle the fix now; repoint it to a `master` commit after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
